### PR TITLE
Update android.js for ionic 3 project structure

### DIFF
--- a/bin/lib/android.js
+++ b/bin/lib/android.js
@@ -156,12 +156,12 @@ module.exports = function (context) {
 
 		return fs.exists('platforms/android')
 			// Write preferences xml file
-			.then(function () { return fs.mkdir('platforms/android/res/xml'); })
-			.then(function () { return fs.writeFile('platforms/android/res/xml/apppreferences.xml', preferencesDocument.write()); })
+			.then(function () { return fs.mkdir('platforms/android/app/src/main/res/xml'); })
+			.then(function () { return fs.writeFile('platforms/android/app/src/main/res/xml/apppreferences.xml', preferencesDocument.write()); })
 
 			// Write localization resource file
-			.then(function () { return fs.mkdir('platforms/android/res/values'); })
-			.then(function (prefs) { return fs.writeFile('platforms/android/res/values/apppreferences.xml', preferencesStringDocument.write()); })
+			.then(function () { return fs.mkdir('platforms/android/app/src/main/res/values'); })
+			.then(function (prefs) { return fs.writeFile('platforms/android/app/src/main/res/values/apppreferences.xml', preferencesStringDocument.write()); })
 
 			.then(function () { console.log('android preferences file was successfully generated'); })
 			.catch(function (err) {


### PR DESCRIPTION
Changed path to refer to android resources according to the new project structure

The android project structure has changed in ionic 3, the old references to the android resources folder is causing compile time errors.